### PR TITLE
Avoid clobbering nrsysmond.cfg.old file

### DIFF
--- a/cookbooks/own_newrelic/recipes/default.rb
+++ b/cookbooks/own_newrelic/recipes/default.rb
@@ -1,10 +1,12 @@
-yourkey = "your new key"
-execute 'replace license key' do
-  command "cp /etc/newrelic/nrsysmond.cfg /etc/newrelic/nrsysmond.cfg.old && sed 's/license_key=.*$/license_key=#{yourkey}/' /etc/newrelic/nrsysmond.cfg.old > /etc/newrelic/nrsysmond.cfg"
+license_key = "your new key"
+config_file = "/etc/newrelic/nrsysmond.cfg"
+execute 'replace New Relic license key' do
+  command "mv #{config_file} #{config_file}.old && sed 's/license_key=.*$/license_key=#{license_key}/' #{config_file}.old > #{config_file}"
   user "root"
+  not_if "grep -q #{license_key} #{config_file}"
 end
 
-execute "restart nrsysmond do" do
+execute "restart nrsysmond" do
   command "/etc/init.d/newrelic-sysmond restart"
   user "root"
 end


### PR DESCRIPTION
Added a `not_if` clause to prevent the second chef run from overwriting the original key.
